### PR TITLE
Update texasinstruments.lbr

### DIFF
--- a/texasinstruments.lbr
+++ b/texasinstruments.lbr
@@ -78,16 +78,16 @@
 <package name="S-PVSON-N10">
 <description>S-PVSON-N10</description>
 <smd name="EXPAD" x="0" y="0" dx="1.6" dy="2.15" layer="1" rot="R90"/>
-<smd name="1" x="-1" y="-1.875" dx="0.825" dy="0.28" layer="1" roundness="1" rot="R90"/>
-<smd name="2" x="-0.5" y="-1.875" dx="0.825" dy="0.28" layer="1" roundness="1" rot="R90"/>
-<smd name="3" x="0" y="-1.875" dx="0.825" dy="0.28" layer="1" roundness="1" rot="R90"/>
-<smd name="4" x="0.5" y="-1.875" dx="0.825" dy="0.28" layer="1" roundness="1" rot="R90"/>
-<smd name="5" x="1" y="-1.875" dx="0.825" dy="0.28" layer="1" roundness="1" rot="R90"/>
-<smd name="6" x="1" y="1.875" dx="0.825" dy="0.28" layer="1" roundness="1" rot="R90"/>
-<smd name="7" x="0.5" y="1.875" dx="0.825" dy="0.28" layer="1" roundness="1" rot="R90"/>
-<smd name="8" x="0" y="1.875" dx="0.825" dy="0.28" layer="1" roundness="1" rot="R90"/>
-<smd name="9" x="-0.5" y="1.875" dx="0.825" dy="0.28" layer="1" roundness="1" rot="R90"/>
-<smd name="10" x="-1" y="1.875" dx="0.825" dy="0.28" layer="1" roundness="1" rot="R90"/>
+<smd name="1" x="-1" y="-1.4625" dx="0.825" dy="0.28" layer="1" roundness="1" rot="R90"/>
+<smd name="2" x="-0.5" y="-1.4625" dx="0.825" dy="0.28" layer="1" roundness="1" rot="R90"/>
+<smd name="3" x="0" y="-1.4625" dx="0.825" dy="0.28" layer="1" roundness="1" rot="R90"/>
+<smd name="4" x="0.5" y="-1.4625" dx="0.825" dy="0.28" layer="1" roundness="1" rot="R90"/>
+<smd name="5" x="1" y="-1.4625" dx="0.825" dy="0.28" layer="1" roundness="1" rot="R90"/>
+<smd name="6" x="1" y="1.4625" dx="0.825" dy="0.28" layer="1" roundness="1" rot="R90"/>
+<smd name="7" x="0.5" y="1.4625" dx="0.825" dy="0.28" layer="1" roundness="1" rot="R90"/>
+<smd name="8" x="0" y="1.4625" dx="0.825" dy="0.28" layer="1" roundness="1" rot="R90"/>
+<smd name="9" x="-0.5" y="1.4625" dx="0.825" dy="0.28" layer="1" roundness="1" rot="R90"/>
+<smd name="10" x="-1" y="1.4625" dx="0.825" dy="0.28" layer="1" roundness="1" rot="R90"/>
 <hole x="-0.75" y="0.5" drill="0.2"/>
 <hole x="0.75" y="0.5" drill="0.2"/>
 <hole x="0.75" y="-0.5" drill="0.2"/>


### PR DESCRIPTION
The pads for the TPS61232 were placed too far out.  They were 1.875 from centerline, 1.4625 appears to be correct per the datasheet.
